### PR TITLE
respawn

### DIFF
--- a/src/game/common/const.mjs
+++ b/src/game/common/const.mjs
@@ -79,6 +79,7 @@ const Command = {
   hubStats: 'hubStats',
   registerSpectator: 'registerSpectator',
   registeredSpectator: 'registeredSpectator',
+  respawned: 'respawned',
 };
 
 const Direction = {
@@ -92,12 +93,12 @@ const Tile = {
   size: 48,
 };
 
-const GameObject = {
-  ap: { type: 'ap', tile: 0, value: 5, rarity: 35 },
-  hp: { type: 'hp', tile: 1, value: 25, rarity: 35 },
-  equipment_mine: { type: 'equipment_mine', tile: 2, value: 20, rarity: 15 },
-  teleport_device: { type: 'teleport_device', tile: 3, value: 50, rarity: 25 },
-  scanner_device: { type: 'scanner_device', tile: 4, value: 50, rarity: 15 },
+export const GameObject = {
+  ap: { type: 'ap', tile: 0, value: 5, rarity: 35, roundsToRespawn: 10 },
+  hp: { type: 'hp', tile: 1, value: 25, rarity: 35, roundsToRespawn: 10 },
+  equipment_mine: { type: 'equipment_mine', tile: 2, value: 20, rarity: 15, roundsToRespawn: 10 },
+  teleport_device: { type: 'teleport_device', tile: 3, value: 50, rarity: 25, roundsToRespawn: 10 },
+  scanner_device: { type: 'scanner_device', tile: 4, value: 50, rarity: 15, roundsToRespawn: 10 },
   none: { type: 'none', tile: 5, value: 0 },
 
   // invisible

--- a/src/game/process/cmd/__init.js
+++ b/src/game/process/cmd/__init.js
@@ -71,6 +71,8 @@ function initState(message, state) {
       .fill([])
       .map(() => Array(mapHeight)),
     obstaclesTilemap: generateTilemap(obstaclesLayer.data, obstaclesLayer.width),
+    gameObjectsToRespawn: {},
+    gameObjectsToRespawnInRound: [],
   };
 
   return result;

--- a/src/game/process/cmd/info.mjs
+++ b/src/game/process/cmd/info.mjs
@@ -1,7 +1,7 @@
 export function gameStats(state) {
-  const { gameTokens, gameTreasuresCounter, lastTxs } = state;
+  const { gameTokens, gameTreasuresCounter, lastTxs, gameObjectsToRespawnInRound } = state;
   return {
-    gameStats: { gameTokens, gameTreasuresCounter, lastTxs },
+    gameStats: { gameTokens, gameTreasuresCounter, lastTxs, gameObjectsToRespawnInRound },
   };
 }
 

--- a/src/game/process/cmd/pick.mjs
+++ b/src/game/process/cmd/pick.mjs
@@ -52,6 +52,7 @@ function pickHP(state, player, value) {
   player.stats.hp.current += value;
   addCoins(player, GameTreasure.cbcoin.type, value);
   state.gameObjectsTilemap[player.pos.y][player.pos.x] = GameObject.none.tile;
+  addGameObjectToRespawn(state, GameObject.hp.type, player);
   return {
     player,
     picked: { type: GameObject.hp.type },
@@ -68,6 +69,7 @@ function pickAP(state, player, value) {
   player.stats.ap.current += value;
   addCoins(player, GameTreasure.cbcoin.type, value);
   state.gameObjectsTilemap[player.pos.y][player.pos.x] = GameObject.none.tile;
+  addGameObjectToRespawn(state, GameObject.ap.type, player);
   return {
     player,
     picked: { type: GameObject.ap.type },
@@ -90,6 +92,7 @@ function pickDevice(state, player, device) {
     player.equipment[equipmentType].current += 1;
     addCoins(player, GameTreasure.cbcoin.type, value);
     state.gameObjectsTilemap[player.pos.y][player.pos.x] = GameObject.none.tile;
+    addGameObjectToRespawn(state, type, player);
     return {
       player,
       picked: { type },
@@ -121,4 +124,18 @@ function pickTreasure(state, player) {
       { value: -1, type: Scores.ap },
     ]),
   };
+}
+
+function addGameObjectToRespawn(state, gameObjectType, player) {
+  const round = state.round.current + GameObject[gameObjectType].roundsToRespawn;
+  let respawnInRound = state.gameObjectsToRespawn[round];
+  const gameObjectToRespawn = { type: gameObjectType, tile: GameObject[gameObjectType].tile, pos: player.pos };
+
+  if (!respawnInRound) {
+    state.gameObjectsToRespawn[round] = [gameObjectToRespawn];
+  } else {
+    state.gameObjectsToRespawn[round].push(gameObjectToRespawn);
+  }
+
+  console.log('respawn in round added', state.gameObjectsToRespawn);
 }

--- a/src/game/process/game.mjs
+++ b/src/game/process/game.mjs
@@ -196,6 +196,8 @@ export function handle(state, message) {
     default:
       throw new ProcessError(`Unknown action: ${action.cmd}`);
   }
+
+  state.gameObjectsToRespawnInRound = [];
 }
 
 function gameRoundTick(state, message) {
@@ -203,6 +205,7 @@ function gameRoundTick(state, message) {
   const tsChange = tsNow - state.round.start;
   const round = ~~(tsChange / state.round.interval);
   console.log('Last round ', state.round);
+  if (state.round.current !== round) respawn(round, state);
   state.round.current = round;
   if (state.playWindow?.roundsTotal) {
     const roundsToGo = state.playWindow?.roundsTotal - state.round.current;
@@ -219,4 +222,19 @@ function gamePlayerTick(state, action) {
     player.stats.ap.current = player.stats.ap.max;
     player.stats.round.last = state.round.current;
   }
+}
+
+function respawn(round, state) {
+  for (let roundToRespawn in state?.gameObjectsToRespawn) {
+    if (roundToRespawn <= round) {
+      for (let gameObjectToRespawn of state?.gameObjectsToRespawn[roundToRespawn]) {
+        const { tile, pos } = gameObjectToRespawn;
+        state.gameObjectsTilemap[pos.y][pos.x] = tile;
+        state.gameObjectsToRespawnInRound.push(gameObjectToRespawn);
+      }
+      delete state.gameObjectsToRespawn[roundToRespawn];
+    }
+  }
+
+  console.log(`No game objects to respawn in round: ${round}`);
 }


### PR DESCRIPTION
Respawn functionality added - items will be respawned on the map after specific number of rounds has passed.

1. item is being picked up by a player, it is added to `state.gameObjectsToRespawn` object (round indicating in which round it will be respawned)
```
state.gameObjectsToRespawn[round] = [{
  type, 
  tile, 
  pos,
}];
```
2. when the game round changes, `state.gameObjectsToRespawn` is being checked for all the items that should be respawned in current and all the previous rounds (if they haven't yet been respawned e.g. due to players' inactivity), items to be respawned are added to `state.gameObjectsToRespawnInRound` array, entry that has been processed is being deleted from `state.gameObjectsToRespawn`
3. `state.gameObjectsToRespawnInRound` is then returned from `gameStats` function (which is called in most of the commands that are being called during the game), after being returned - `state.gameObjectsToRespawnInRound` array is being emptied
4. what has been returned to the game client from p. 3 is then handled by the MainScene in `handleRespawned` function - for each of the respawned objects new tile is put on `gameObjectsLayer`, new sprite is being created based on this tile in `createSpriteFromTile` function and after creating the sprite, tile is being removed (note that this sprite is handled differently than sprites initially created for the tilemap, otherwise we would need to recreate the whole tilemap - check `src/game/scenes/main-scene/maps.js` for further info)